### PR TITLE
add data attribute to disable automatic routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Normally an [`anchor element`](https://developer.mozilla.org/en-US/docs/Web/HTML
 
 There are many advantages of using an anchor element, the main one being accessibility.
 
+Alternatively, if you would still like to allow relative links to other parts of your site to navigate as normally, you can opt out of this behavior on a link-by-link basis:
+
+```html
+<a href="/about" data-router-slot="disable">Go to about!</a>
+```
+
 #### `router-link`
 
 With the `router-link` component you add `<router-link>` to your markup and specify a path. Whenever the component is clicked it will navigate to the specified path. Whenever the path of the router link is active the active attribute is set.

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ There are many advantages of using an anchor element, the main one being accessi
 Alternatively, if you would still like to allow relative links to other parts of your site to navigate as normally, you can opt out of this behavior on a link-by-link basis:
 
 ```html
-<a href="/about" data-router-slot="disable">Go to about!</a>
+<a href="/about" data-router-slot="disabled">Go to about!</a>
 ```
 
 #### `router-link`

--- a/blueprint.md
+++ b/blueprint.md
@@ -115,6 +115,12 @@ Normally an [`anchor element`](https://developer.mozilla.org/en-US/docs/Web/HTML
 
 There are many advantages of using an anchor element, the main one being accessibility.
 
+Alternatively, if you would still like to allow relative links to other parts of your site to navigate as normally, you can opt out of this behavior on a link-by-link basis:
+
+```html
+<a href="/about" data-router-slot="disable">Go to about!</a>
+```
+
 #### `router-link`
 
 With the `router-link` component you add `<router-link>` to your markup and specify a path. Whenever the component is clicked it will navigate to the specified path. Whenever the path of the router link is active the active attribute is set.

--- a/blueprint.md
+++ b/blueprint.md
@@ -118,7 +118,7 @@ There are many advantages of using an anchor element, the main one being accessi
 Alternatively, if you would still like to allow relative links to other parts of your site to navigate as normally, you can opt out of this behavior on a link-by-link basis:
 
 ```html
-<a href="/about" data-router-slot="disable">Go to about!</a>
+<a href="/about" data-router-slot="disabled">Go to about!</a>
 ```
 
 #### `router-link`

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -22,7 +22,7 @@ export function ensureAnchorHistory () {
 		// allow the default behavior (eg. if it should open in a new tab)
 		if (!href.startsWith(location.origin) ||
 		   ($anchor.target !== "" && $anchor.target !== "_self") ||
-		   $anchor.dataset["routerSlot"] === "disable") {
+		   $anchor.dataset["routerSlot"] === "disabled") {
 			return;
 		}
 

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -2,8 +2,6 @@
  * Hook up a click listener to the window that, for all anchor tags
  * that has a relative HREF, uses the history API instead.
  */
-import { stripStart } from "./url";
-
 export function ensureAnchorHistory () {
 	window.addEventListener("click", (e: MouseEvent) => {
 
@@ -22,7 +20,9 @@ export function ensureAnchorHistory () {
 		// We want to allow links to absolute paths without
 		// using the history API. Also, if the target is not this frame we
 		// allow the default behavior (eg. if it should open in a new tab)
-		if (!href.startsWith(location.origin) || ($anchor.target !== "" && $anchor.target !== "_self")) {
+		if (!href.startsWith(location.origin) ||
+			($anchor.target !== "" && $anchor.target !== "_self") ||
+			$anchor.dataset["routerSlot"] === "disable") {
 			return;
 		}
 

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -21,8 +21,8 @@ export function ensureAnchorHistory () {
 		// using the history API. Also, if the target is not this frame we
 		// allow the default behavior (eg. if it should open in a new tab)
 		if (!href.startsWith(location.origin) ||
-			($anchor.target !== "" && $anchor.target !== "_self") ||
-			$anchor.dataset["routerSlot"] === "disable") {
+		   ($anchor.target !== "" && $anchor.target !== "_self") ||
+		   $anchor.dataset["routerSlot"] === "disable") {
 			return;
 		}
 


### PR DESCRIPTION
Hi 👋! So far I love your router! It has all I'm looking for in one for our site. We have a site that will not be 100% SPA, but we would still like to use relative paths everywhere though. Since we have local, staging and production environments, using absolute urls everywhere would be a pain. I think it would be reasonable to allow users to opt out of the automatic History.pushState behavior with relative paths if need be.