### PR TITLE
Add metaKey and target support for opening a link in a new tab

### DIFF
--- a/src/demo/pages/home/user/user.ts
+++ b/src/demo/pages/home/user/user.ts
@@ -43,6 +43,7 @@ export default class UserComponent extends LitElement {
 			<p>:user = <b>${user}</b></p>
 			<p>:dashId = <b>${dashId}</b></p>
 			<router-link path="edit">Go to EditComponent</router-link>
+			<router-link path="edit" target="_blank">Open EditComponent in New Tab</router-link>
 			<router-slot @changestate="${(e: Event) => console.log("State changed", e)}"></router-slot>
 		`;
 	}

--- a/src/lib/router-link.ts
+++ b/src/lib/router-link.ts
@@ -194,7 +194,16 @@ export class RouterLink extends HTMLElement {
 			return;
 		}
 
-		history.pushState(null, "", `${this.absolutePath}${this.preserveQuery ? queryString() : ""}`);
+		const query = this.preserveQuery ? queryString() : "";
+		const destination = `${this.absolutePath}${query}`;
+
+		// If user is holding down metaKey when clicking, open in new tab
+		if (e instanceof MouseEvent && (e as MouseEvent).metaKey) {
+			window.open(destination, '_blank');
+			return;
+		}
+
+		history.pushState(null, "", destination);
 	}
 }
 

--- a/src/lib/router-link.ts
+++ b/src/lib/router-link.ts
@@ -33,6 +33,14 @@ export class RouterLink extends HTMLElement {
 	}
 
 	/**
+	 * The link target, equivalent of <a target>.
+	 * @attr
+	 */
+	get target(): string | null {
+		return this.getAttribute("target");
+	}
+
+	/**
 	 * Whether the element is disabled or not.
 	 * @attr
 	 */
@@ -196,6 +204,11 @@ export class RouterLink extends HTMLElement {
 
 		const query = this.preserveQuery ? queryString() : "";
 		const destination = `${this.absolutePath}${query}`;
+
+		if (this.target) {
+			window.open(destination, this.target);
+			return;
+		}
 
 		// If user is holding down metaKey when clicking, open in new tab
 		if (e instanceof MouseEvent && (e as MouseEvent).metaKey) {

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -4,6 +4,9 @@
  */
 export function ensureAnchorHistory () {
 	window.addEventListener("click", (e: MouseEvent) => {
+		// holding down the metaKey (Command on Mac, Control on Windows)
+		// is used to open a link in a new tab so let the browser handle it
+		if (e.metaKey) return;
 
 		// Find the target by using the composed path to get the element through the shadow boundaries.
 		const $anchor = ("composedPath" in e as any) ? e.composedPath().find($elem => $elem instanceof HTMLAnchorElement) : e.target;

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -4,10 +4,6 @@
  */
 export function ensureAnchorHistory () {
 	window.addEventListener("click", (e: MouseEvent) => {
-		// holding down the metaKey (Command on Mac, Control on Windows)
-		// is used to open a link in a new tab so let the browser handle it
-		if (e.metaKey) return;
-
 		// Find the target by using the composed path to get the element through the shadow boundaries.
 		const $anchor = ("composedPath" in e as any) ? e.composedPath().find($elem => $elem instanceof HTMLAnchorElement) : e.target;
 
@@ -15,6 +11,10 @@ export function ensureAnchorHistory () {
 		if ($anchor == null || !($anchor instanceof HTMLAnchorElement)) {
 			return;
 		}
+
+		// holding down the metaKey (Command on Mac, Control on Windows)
+		// is used to open a link in a new tab so let the browser handle it
+		if (e.metaKey) return;
 
 		// Get the HREF value from the anchor tag
 		const href = $anchor.href;

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -12,10 +12,6 @@ export function ensureAnchorHistory () {
 			return;
 		}
 
-		// holding down the metaKey (Command on Mac, Control on Windows)
-		// is used to open a link in a new tab so let the browser handle it
-		if (e.metaKey) return;
-
 		// Get the HREF value from the anchor tag
 		const href = $anchor.href;
 
@@ -26,6 +22,12 @@ export function ensureAnchorHistory () {
 		if (!href.startsWith(location.origin) ||
 		   ($anchor.target !== "" && $anchor.target !== "_self") ||
 		   $anchor.dataset["routerSlot"] === "disabled") {
+			return;
+		}
+
+		// Holding down the metaKey (Command on Mac, Control on Windows)
+		// is used to open a link in a new tab so let the browser handle it
+		if (e.metaKey) {
 			return;
 		}
 


### PR DESCRIPTION
If users hold down the metaKey (Command on Mac, Control on Windows), it's usually to open the link in a new tab. This allows the browser to handle the metaKey case for anchor links and `router-link` tags, as well as adding `target` support to `router-link`.