### PR TITLE
Allow browser to handle anchor tags with no route

### DIFF
--- a/src/lib/model.ts
+++ b/src/lib/model.ts
@@ -11,6 +11,8 @@ export interface IRouterSlot<D = any, P = any> extends HTMLElement {
 	constructAbsolutePath: ((path: PathFragment) => string);
 	parent: IRouterSlot<P> | null | undefined;
 	queryParentRouterSlot: (() => IRouterSlot<P> | null);
+	// Return the matched route if one found for the given path
+	getRouteMatch(path: string | PathFragment): IRouteMatch<D> | null;
 }
 
 export type IRoutingInfo<D = any, P = any> = {

--- a/src/lib/router-slot.ts
+++ b/src/lib/router-slot.ts
@@ -160,6 +160,15 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	}
 
 	/**
+	 * Return a route match for a given path or null if there's no match
+	 * @param path
+	 */
+	getRouteMatch(path: string | PathFragment): IRouteMatch<D> | null {
+		const match = matchRoutes(this._routes, path);
+		return match;
+	}
+
+	/**
 	 * Each time the path changes, load the new path.
 	 */
 	async render (): Promise<void> {
@@ -226,11 +235,6 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	 */
 	protected detachListeners (): void {
 		removeListeners(this.listeners);
-	}
-
-	getRouteMatch(path: string | PathFragment): IRouteMatch<D> | null {
-		const match = matchRoutes(this._routes, path);
-		return match;
 	}
 
 	/**

--- a/src/lib/router-slot.ts
+++ b/src/lib/router-slot.ts
@@ -1,6 +1,6 @@
 import { GLOBAL_ROUTER_EVENTS_TARGET, ROUTER_SLOT_TAG_NAME } from "./config";
 import { Cancel, EventListenerSubscription, GlobalRouterEvent, IPathFragments, IRoute, IRouteMatch, IRouterSlot, IRoutingInfo, Params, PathFragment, RouterSlotEvent } from "./model";
-import { addListener, AnchorHandler, constructAbsolutePath, dispatchGlobalRouterEvent, dispatchRouteChangeEvent, ensureHistoryEvents, handleRedirect, isRedirectRoute, isResolverRoute, matchRoutes, pathWithoutBasePath, queryParentRouterSlot, removeListeners, resolvePageComponent, shouldNavigate } from "./util";
+import { addListener, AnchorHandler, constructAbsolutePath, dispatchGlobalRouterEvent, dispatchRouteChangeEvent, ensureHistoryEvents, handleRedirect, IAnchorHandler, isRedirectRoute, isResolverRoute, matchRoutes, pathWithoutBasePath, queryParentRouterSlot, removeListeners, resolvePageComponent, shouldNavigate } from "./util";
 
 const template = document.createElement("template");
 template.innerHTML = `<slot></slot>`;
@@ -89,7 +89,7 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	/**
 	 * The anchor link handler for the router slot
 	 */
-	private anchorHandler?: AnchorHandler;
+	private anchorHandler?: IAnchorHandler;
 
 	/**
 	 * Hooks up the element.
@@ -188,19 +188,11 @@ export class RouterSlot<D = any, P = any> extends HTMLElement implements IRouter
 	 */
 	protected setupAnchorListener(): void {
 		this.anchorHandler = new AnchorHandler(this);
-		window.addEventListener(
-			'click',
-			this.anchorHandler?.handleEvent.bind(this)
-		);
+		this.anchorHandler?.setup();
 	}
 
 	protected detachAnchorListener(): void {
-		if (this.anchorHandler) {
-			window.removeEventListener(
-				'click',
-				this.anchorHandler.handleEvent
-			);
-		}
+		this.anchorHandler?.teardown();
 	}
 
 	/**

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -52,7 +52,17 @@ export class AnchorHandler implements IAnchorHandler {
 		// - 4. The router can handle the route
 		const routeMatched = this.routerSlot?.getRouteMatch($anchor.pathname);
 
-		if (!hrefIsRelative || differentFrameTargetted || isDisabled || !routeMatched) {
+		// - 5. User is not holding down metaKey (Command on Mac, Control on Windows)
+		//      which is typically used to open a new tab.
+		const userIsHoldingMetaKey = e.metaKey;
+
+		if (
+			!hrefIsRelative ||
+			differentFrameTargetted ||
+			isDisabled ||
+			!routeMatched ||
+			userIsHoldingMetaKey
+		) {
 			return;
 		}
 

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -1,17 +1,36 @@
-import { IRouterSlot } from "../model";
+import type { IRouterSlot } from "../model";
+
+export interface IAnchorHandler {
+	setup(): void;
+	teardown(): void;
+}
 
 /**
  * The AnchorHandler allows the RouterSlot to observe all anchor clicks
  * and either handle the click or let the browser handle it.
  */
-export class AnchorHandler {
+export class AnchorHandler implements IAnchorHandler {
 	routerSlot?: IRouterSlot;
 
 	constructor(routerSlot?: IRouterSlot) {
 		this.routerSlot = routerSlot;
 	}
 
-	handleEvent(e: MouseEvent) {
+	setup(): void {
+		window.addEventListener(
+			'click',
+			(e) => this.handleEvent(e)
+		);
+	}
+
+	teardown(): void {
+		window.removeEventListener(
+			'click',
+			(e) => this.handleEvent(e)
+		);
+	}
+
+	private handleEvent(e: MouseEvent) {
 		// Find the target by using the composed path to get the element through the shadow boundaries.
 		const $anchor = ("composedPath" in e as any) ? e.composedPath().find($elem => $elem instanceof HTMLAnchorElement) : e.target;
 
@@ -38,7 +57,7 @@ export class AnchorHandler {
 		}
 
 		// Remove the origin from the start of the HREF to get the path
-		const path = $anchor.pathname;
+		const path = `${$anchor.pathname}${$anchor.search}`;
 
 		// Prevent the default behavior
 		e.preventDefault();

--- a/src/lib/util/anchor.ts
+++ b/src/lib/util/anchor.ts
@@ -52,7 +52,7 @@ export class AnchorHandler implements IAnchorHandler {
 		// - 4. The router can handle the route
 		const routeMatched = this.routerSlot?.getRouteMatch($anchor.pathname);
 
-		// - 5. User is not holding down metaKey (Command on Mac, Control on Windows)
+		// - 5. User is not holding down the meta key, (Command on Mac, Control on Windows)
 		//      which is typically used to open a new tab.
 		const userIsHoldingMetaKey = e.metaKey;
 


### PR DESCRIPTION
The use case for this is integrating `router-slot` into a server-side routed web app where we're proxy-passing from the same parent URL. The URLs are relative so `router-slot` tries to handle them, even though they are on a different host and the catch-all route handles it.

We don't yet have client-side routes for all of the server-side routes so by not including a catch-all route, we can allow the browser handle the anchor and get directed to the server-side route.

If the app has a catch-all route, it will still be handled client-side.